### PR TITLE
add JsoniterSpi.clearCaches

### DIFF
--- a/src/main/java/com/jsoniter/spi/JsoniterSpi.java
+++ b/src/main/java/com/jsoniter/spi/JsoniterSpi.java
@@ -291,6 +291,15 @@ public class JsoniterSpi {
         objectFactories = copy;
     }
 
+    public static synchronized void clearCaches() {
+        mapKeyEncoders = new HashMap<>();
+        mapKeyDecoders = new HashMap<>();
+        encoders = new HashMap<>();
+        decoders = new HashMap<>();
+        objectFactories = new HashMap<>();
+    }
+
+    
     private static class TypeProperty {
 
         public final Type type;


### PR DESCRIPTION
since the cache may contain entries referring to classes whose classloader is disposed, there must be a way to get rid of them